### PR TITLE
Don't check for __xhr

### DIFF
--- a/graphql.js
+++ b/graphql.js
@@ -25,18 +25,10 @@
     return extended
   }
   
-  function __xhr() {
-    if (window.XMLHttpRequest) {
-      return new window.XMLHttpRequest
-    } else {
-      try { return new ActiveXObject("MSXML2.XMLHTTP.3.0") } catch(ex) { return null }
-    }
-  }
-  
   function __request(method, url, headers, data, callback) {
     var body = "query=" + escape(data.query) + "&variables=" + escape(JSON.stringify(data.variables))
     if (typeof XMLHttpRequest != 'undefined') {
-      var xhr = __xhr()
+      var xhr = new XMLHttpRequest
       xhr.open(method, url, true)
       xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded')
       xhr.setRequestHeader('Accept', 'application/json')


### PR DESCRIPTION
Since the test for running in a browser - calling `__xhr` after `typeof XMLHttpRequest != "undefined"` would always return `XMLHttpRequest` anyway, so we might as well call it directly and avoid the abstraction.