### PR TITLE
Add onRequestError option

### DIFF
--- a/graphql.js
+++ b/graphql.js
@@ -31,7 +31,7 @@
     })
   }
 
-  function __request(method, url, headers, data, asJson, callback) {
+  function __request(method, url, headers, data, asJson, onRequestError, callback) {
     if (!url) {
       return;
     }
@@ -76,6 +76,11 @@
           callback(JSON.parse(str), response.statusCode)
         })
       })
+      if (typeof onRequestError === 'function') {
+        req.on('error', function (err) {
+          onRequestError(err);
+        });
+      }
       req.write(body)
       req.end()
     }
@@ -272,7 +277,7 @@
           __request(that.options.method || "post", that.getUrl(), headers, {
             query: fragmentedQuery,
             variables: that.cleanAutoDeclareAnnotations(variables)
-          }, !!that.options.asJSON, function (response, status) {
+          }, !!that.options.asJSON, that.options.onRequestError, function (response, status) {
             if (status == 200) {
               if (response.errors) {
                 reject(response.errors)


### PR DESCRIPTION
Thanks for the package!

If a request error occurs, such as `ECONNREFUSED` due to the host being inaccessible, it currently kills the Node process. This option allows you to catch and handle such exceptions.

I can add tests and documentation, but I wanted to first verify that this is the correct approach. For my purposes it's best to have this as a client option and catch in one place, but I'm not sure if anyone would want to provide the option when executing a specific query.

Example usage:

```js
const graph = graphql(`${MAIN_API_URL}/graphql`, {
  asJSON: true,
  onRequestError(err) {
    console.error('GRAPHQL REQUEST ERROR', err.message);
  },
});
```