### PR TITLE
Fix edge case where response gets lost

### DIFF
--- a/graphql.js
+++ b/graphql.js
@@ -278,6 +278,8 @@
                 reject(response.errors)
               } else if (response.data) {
                 resolve(response.data)
+              } else {
+                resolve(response)
               }
             } else {
               reject(response)


### PR DESCRIPTION
Hey!

I just started using graphql.js (thank you very much for creating a lightweight alternative to Apollo!) and stumbled upon a bug: When I use `asJson: true`, the Promise never gets resolved, because `response.data` doesn't exist.

That's why I added a final `else` branch, to ensure that the Promise will always resolve.